### PR TITLE
Add retrigger content logic from django admin

### DIFF
--- a/content/admin.py
+++ b/content/admin.py
@@ -1,7 +1,9 @@
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.utils.safestring import mark_safe
 
 from common.admin import UserResourceAdmin
 from content.models import Content, Tag
+from content.tasks import create_embedding_for_content_task
 
 # Register your models here.
 
@@ -14,6 +16,29 @@ class TagAdmin(admin.ModelAdmin):
 
 @admin.register(Content)
 class ContentAdmin(UserResourceAdmin):
-    list_display = ["title", "content_id"]
+    list_display = [
+        "title",
+        "content_id",
+        "document_status",
+    ]
     autocomplete_fields = ["deleted_by", "tag"]
     readonly_fields = ["document_status", "document_type"]
+
+    actions = ["retrigger_content_processing"]
+
+    def retrigger_content_processing(self, request, queryset):
+        """
+        Trigger content processing for selected content.
+        """
+        for content in queryset:
+            if content.document_status == Content.DocumentStatus.ADDED_TO_VECTOR:
+                messages.add_message(request, messages.WARNING, mark_safe(f"Content {content.title} is already processed."))
+            else:
+
+                create_embedding_for_content_task.delay(content.id)
+
+                messages.add_message(
+                    request, messages.INFO, mark_safe("Successfully triggered content processing for selected contents!")
+                )
+
+    retrigger_content_processing.short_description = "Re-trigger content processing"


### PR DESCRIPTION

## Changes

* Add retrigger content feature from django admin 


## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
