### PR TITLE
Add frontend host to trusted origin list in setting

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -117,6 +117,7 @@ if APP_HTTP_PROTOCOL == "https":
     SECURE_HSTS_PRELOAD = True
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
     CSRF_TRUSTED_ORIGINS = [
+        APP_FRONTEND_HOST,
         f"{APP_HTTP_PROTOCOL}://{APP_DOMAIN}",
     ]
 # Note: The embedding model and vector size both should be compatible


### PR DESCRIPTION

* Add frontend host to trusted origin list in setting file 

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
