### PR TITLE
Update configmap and add env for app type and domain

### DIFF
--- a/helm/templates/config/configmap.yaml
+++ b/helm/templates/config/configmap.yaml
@@ -7,13 +7,15 @@ metadata:
     environment: {{ .Values.environment }}
     release: {{ .Release.Name }}
 data:
-  APP_ENVIRONMENT: {{ .Values.environment | upper | quote }} 
-  APP_DOMAIN: {{ required "env.APP_DOMAIN" .Values.environment | upper | quote }} 
-  APP_FRONTEND_HOST: {{ required "env.APP_FRONTEND_HOST" .Values.environment | quote }} 
+  APP_ENVIRONMENT: {{ .Values.environment | upper | quote }}
+  # App Domain 
+  APP_DOMAIN: {{ required "env.APP_DOMAIN" .Values.env.APP_DOMAIN  | quote }} 
+  APP_FRONTEND_HOST: {{ required "env.APP_FRONTEND_HOST" .Values.env.APP_FRONTEND_HOST | quote }} 
+  APP_HTTP_PROTOCOL: {{ required "env.APP_HTTP_PROTOCOL" .Values.env.APP_HTTP_PROTOCOL | quote }}
+  APP_TYPE: {{  .Values.env.APP_TYPE  | quote }}
   DJANGO_TIME_ZONE: {{ .Values.env.DJANGO_TIME_ZONE }}
   DJANGO_DEBUG: {{ .Values.env.DJANGO_DEBUG | quote }}
   DJANGO_ALLOWED_HOST: {{ .Values.env.DJANGO_ALLOWED_HOST | quote }}
-  APP_HTTP_PROTOCOL: {{ .Values.env.APP_HTTP_PROTOCOL | quote }}
 
   # Email
   DEFAULT_FROM_EMAIL: {{ required "env.DEFAULT_FROM_EMAIL" .Values.env.DEFAULT_FROM_EMAIL | quote }}

--- a/helm/values-test.yaml
+++ b/helm/values-test.yaml
@@ -9,6 +9,9 @@ ingress:
 
 env:
   # App Domain
+  APP_DOMAIN: test-domain.com
+  APP_HTTP_PROTOCOL: https
+  APP_FRONTEND_HOST: test.com
   # Vector Database
   QDRANT_DB_HOST: test.com
   QDRANT_DB_PORT: 1234

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -144,6 +144,7 @@ env:
   APP_HTTP_PROTOCOL: https
   APP_FRONTEND_HOST:
   APP_DOMAIN:
+  APP_TYPE: 
   # Redis (Required if redis.enabled is false)
   CELERY_REDIS_URL:
   DJANGO_CACHE_REDIS_URL:


### PR DESCRIPTION

## Changes

* Add app domain and app type on configmap 

## This PR doesn't introduce any:

- [X] temporary files, auto-generated files or secret keys
- [X] n+1 queries
- [X] flake8 issues
- [X] `print`
- [X] typos
- [X] unwanted comments

## This PR contains valid:

- [ ] tests
- [ ] permission checks (tests here too)
