### PR TITLE
chore(chart): Update bitnami images to legacy

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,6 +5,10 @@ image:
   tag: SET-BY-CICD-TAG
   imagePullPolicy: IfNotPresent
 
+global:
+  security:
+    allowInsecureImages: true
+
 ingress:
   className: nginx
   api:
@@ -20,6 +24,8 @@ ingress:
 
 postgresql:
   enabled: true
+  image:
+    repository: bitnamilegacy/postgresql
   architecture: standalone
   auth:
     database: chatbot
@@ -36,6 +42,8 @@ postgresql:
 
 redis:
   enabled: true
+  image:
+    repository: bitnamilegacy/redis
   architecture: standalone
   auth:
     enabled: false


### PR DESCRIPTION
## Changes

* Updated bitnami images of postgresql and redis
* Added global security rule to allow insecure images

## This PR doesn't introduce any:

- [x] temporary files, auto-generated files or secret keys
- [x] n+1 queries
- [x] flake8 issues
- [x] `print`
- [x] typos
- [x] unwanted comments

## This PR contains valid:

- [x] tests
- [x] permission checks (tests here too)
